### PR TITLE
Do not create plans by default

### DIFF
--- a/dartplan/api/plans.py
+++ b/dartplan/api/plans.py
@@ -1,7 +1,7 @@
 from flask import g
 from flask_restful import Resource, marshal, fields, reqparse, inputs
 
-from dartplan.authorization import plan_owned_by_user, is_pro_user
+from dartplan.authorization import plan_owned_by_user, can_create_new_plan
 from dartplan.login import login_required
 from dartplan.models import Plan
 from dartplan.database import db
@@ -43,7 +43,7 @@ class PlanListAPI(Resource):
     def get(self):
         return {'plans': [marshal(plan, plan_fields) for plan in g.user.plans]}
 
-    @is_pro_user
+    @can_create_new_plan
     @login_required
     def post(self):
         args = self.reqparse.parse_args()

--- a/dartplan/api/users.py
+++ b/dartplan/api/users.py
@@ -14,6 +14,11 @@ class getIsPro(fields.Raw):
     def output(self, key, user):
         return user.is_pro()
 
+
+class getNumberOfPlans(fields.Raw):
+    def output(self, key, user):
+        return user.plans.count()
+
 user_fields = {
     'id': fields.Integer,
     'nickname': fields.String,
@@ -22,7 +27,8 @@ user_fields = {
     'grad_year': fields.Integer,
     'email_course_updates': fields.Boolean,
     'email_Dartplan_updates': fields.Boolean,
-    'is_pro': getIsPro
+    'is_pro': getIsPro,
+    'number_of_plans': getNumberOfPlans
 }
 
 

--- a/dartplan/authorization.py
+++ b/dartplan/authorization.py
@@ -19,12 +19,14 @@ def plan_owned_by_user(fn):
     return wrapper
 
 
-# Wrapper function so no one can view someone else's plan
-def is_pro_user(fn):
+# Wrapper function so no only those on PRO or without a plan can
+# create a new one
+def can_create_new_plan(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        if g.user and g.user.is_pro():
-            return fn(*args, **kwargs)
+        if g.user:
+            if g.user.is_pro() or (g.user.plans.count() == 0):
+                return fn(*args, **kwargs)
 
         return abort(401)
 

--- a/dartplan/frontend/coffee/controllers.coffee
+++ b/dartplan/frontend/coffee/controllers.coffee
@@ -44,7 +44,7 @@ dartplanApp.controller 'PlansController', ['$scope', '$mdDialog', '$location', '
     $scope.plans = plans
 
     $scope.showNewPlanDialog = ->
-      if $scope.isProUser()
+      if $scope.isProUser() || ($scope.user.number_of_plans == 0)
         $mdDialog.show({
           controller: NewPlanDialogController,
           scope: $scope,

--- a/dartplan/frontend/coffee/users.coffee
+++ b/dartplan/frontend/coffee/users.coffee
@@ -3,7 +3,7 @@ dartplanApp = angular.module 'dartplanApp'
 dartplanApp.factory 'User', ->
   class User
     constructor: (options) ->
-      {@id, @nickname, @netid, @email, @grad_year, @is_pro, @email_course_updates, @email_Dartplan_updates} = options
+      {@id, @nickname, @netid, @email, @grad_year, @is_pro, @number_of_plans, @email_course_updates, @email_Dartplan_updates} = options
 
     class_year: ->
       @grad_year % 100

--- a/dartplan/frontend/frontend.py
+++ b/dartplan/frontend/frontend.py
@@ -34,10 +34,6 @@ def fetch_user():
             db.session.add(g.user)
             db.session.commit()
 
-            plan = Plan(user_id=g.user.id)
-            db.session.add(plan)
-            db.session.commit()
-
             return (redirect(url_for('frontend.edit')))
     else:
         g.user = None
@@ -97,10 +93,7 @@ def edit():
                                   g.user.email_Dartplan_updates
                                   })
 
-        plan = g.user.plans.first()
-        plan.reset_terms()
-
-        return redirect(url_for('frontend.planner'))
+        return redirect(url_for('frontend.plans'))
     return render_template('edit.html',
                            form=form, title='Edit Profile',
                            description="Change the nickname, graduation year, \

--- a/dartplan/frontend/static/partials/pro.html
+++ b/dartplan/frontend/static/partials/pro.html
@@ -6,11 +6,11 @@
     <p><i>Gain exclusive access to premium features, including:</i></p>
 
     <div class='md-title'>Multiple Plans</div>
-    <p>Want to see what your courseload would look like with that double major? Not sure senior spring will be easy enough if you take that FSP next winter? With DARTPlan Pro, there's no limit to the number of D-Plans you can create.</p>
+    <p>Want to see what your course-load would look like with that double major? Not sure senior spring will be easy enough if you take that FSP next winter? With DARTPlan Pro, there's no limit to the number of D-Plans you can create.</p>
 
     <p class='md-headline'>Pricing</p>
     <p>So how much does this cost? You decide!</p>
-    <p>For a limited time, DARTPlan Pro is name-your-own-price. Venmo us <a ng-href='https://venmo.com/dartplan'>@dartplan</a> with a donation of at least $1. Please allow up to 2 hours for our systems to approve your request.</p>
+    <p>For a limited time, DARTPlan Pro is name-your-own-price. Venmo us <a ng-href='https://venmo.com/dartplan'>@dartplan</a> with a donation of at least $1 to sign up for DARTPlan Pro. Please allow up to 2 hours for our systems to approve your request.</p>
 
     <div layout='column' layout-align="center center" >
       <md-button ng-href='https://venmo.com/dartplan' target='_blank' class="md-raised md-accent">

--- a/tests/test_api/test_plans.py
+++ b/tests/test_api/test_plans.py
@@ -35,9 +35,9 @@ class TestPlanListAPI(TestBase):
         assert plan_data.get('title') == 'My Plan'
         assert plan_data.get('fifth_year')
 
-    def test_post_plans_unauthorized(self, test_client, user):
+    def test_post_plans_unauthorized(self, test_client, plan):
         with test_client.session_transaction() as sess:
-            sess['user'] = {'netid': user.netid}
+            sess['user'] = {'netid': plan.user.netid}
 
         data = {'title': 'My Plan', 'fifth_year': True}
 

--- a/tests/test_api/test_users.py
+++ b/tests/test_api/test_users.py
@@ -17,6 +17,8 @@ class TestUserAPI(TestBase):
         assert data['user']['nickname'] == user.nickname
         assert data['user']['email'] == "%s@dartmouth.edu" % user.netid
         assert not data['user']['is_pro']
+        assert data['user']['number_of_plans'] == 0
+
 
     def test_delete_user(self, test_client, plan):
         with test_client.session_transaction() as sess:


### PR DESCRIPTION
1. We want to make sure people are routed through the My Plans page when joining.

2. We want users to be required to fill out a title when they create a new plan.